### PR TITLE
Implement jit0-arm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ interpreter
 jit-x64
 jit-x64.h
 jit0-x64
+jit0-arm

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BIN = interpreter compiler-x64 compiler-arm \
-      jit0-x64 jit-x64
+      jit0-x64 jit-x64 jit0-arm
 
 CROSS_COMPILE = arm-linux-gnueabihf-
 QEMU_ARM = qemu-arm -L /usr/arm-linux-gnueabihf
@@ -36,6 +36,10 @@ jit-x64.h: jit-x64.dasc
 run-jit-x64: jit-x64
 	./jit-x64 progs/hello.b && objdump -D -b binary \
 		-mi386 -Mx86-64 /tmp/jitcode
+
+jit0-arm: jit0-arm.c
+	$(CROSS_COMPILE)gcc $(CFLAGS) -o $@ $^
+
 
 test: test_vector test_stack
 	./test_vector && ./test_stack

--- a/jit0-arm.c
+++ b/jit0-arm.c
@@ -1,0 +1,39 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+
+int main(int argc, char *argv[]) {
+  // Machine code for:
+  // 000082e0 <main>:
+  // 82e0:      e3a00000        mov     r0, #0
+  // 82e4:      e12fff1e        bx      lr
+
+  char code[] = {
+    0x00, 0x00, 0xa0, 0xe3, // 0xe3a00000
+    0x1e, 0xff, 0x2f, 0xe1  // 0xe12fff1e
+  };
+
+  if (argc < 2) {
+    fprintf(stderr, "Usage: jit0-arm <integer>\n");
+    return 1;
+  }
+
+  // Overwrite immediate value "0" in the instruction
+  // with the user's value.  This will make our code:
+  //   mov r0, <user's value>
+  //   bx lr
+  int num = atoi(argv[1]);
+  memcpy(&code[0], &num, 2);
+
+  // Allocate writable/executable memory.
+  // Note: real programs should not map memory both writable
+  // and executable because it is a security risk.
+  void *mem = mmap(NULL, sizeof(code), PROT_WRITE | PROT_EXEC,
+                   MAP_ANON | MAP_PRIVATE, -1, 0);
+  memcpy(mem, code, sizeof(code));
+
+  // The function will return the user's value.
+  int (*func)() = mem;
+  return func();
+}

--- a/jit0-arm.c
+++ b/jit0-arm.c
@@ -33,6 +33,17 @@ int main(int argc, char *argv[]) {
                    MAP_ANON | MAP_PRIVATE, -1, 0);
   memcpy(mem, code, sizeof(code));
 
+  // Clear caches to prevent self-modifying code execute failed due to I-cache
+  // and D-cache not coherent.
+  //
+  // Please see:
+  // http://community.arm.com/groups/processors/blog/2010/02/17/caches-and-self-modifying-code
+#if defined(__GNUC__)
+  __builtin___clear_cache((char*) mem, (char*) (mem + sizeof(code)));
+#else
+#error "Missing builtin to flush instruction cache."
+#endif
+
   // The function will return the user's value.
   int (*func)() = mem;
   return func();


### PR DESCRIPTION
Add jit0-arm implementation. Note that in commit 92157c6 we add `__buildtin_clear_cache()` method to prevent self-modifying code execute failed on real device.

I have tested it on Freescale i.MX6DL (Cortex-A9), without clear cache, this application will encounter segmentation fault.
